### PR TITLE
css résolu pour aligner les radio buttons

### DIFF
--- a/app/assets/stylesheets/components/_sondage.scss
+++ b/app/assets/stylesheets/components/_sondage.scss
@@ -23,6 +23,26 @@ body {
   color: #6A79A6;
   display: inline-block;
   padding: 0em 2em;
-  margin: 6em auto;
+  margin: 3em auto;
   box-shadow: 0 50px 50px rgba(0, 0, 0, .2);
+}
+
+.form-group {
+  .control-label {
+    text-align: center;
+  }
+  .radio {
+    text-align: left;
+    margin-left: calc(50% - 100px);
+    line-height: 22px;
+    label {
+      margin: 0px 0px 0px 0px;
+      vertical-align: middle;
+    }
+    input {
+      margin: 0px 3px 0px 0px;
+      position: inherit;
+      vertical-align: middle;
+    }
+  }
 }

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,53 +1,57 @@
-<%= simple_form_for @user, remote: true do |u| %>
-  <%= u.input :amount_bracket,
-      label: "Combien avez-vous donné en 2017 à des associations ?",
-      collection: User.amount_brackets, as: :radio_buttons,
-      wrapper_html: { class: 'q1' } %>
-  <%= u.input :cause,
-      label: "A quelle cause donneriez-vous (plus) si vous le pouviez ?",
-      collection: User.causes, as: :radio_buttons,
-      wrapper_html: { class: 'q2' } %>
-  <%= u.input :own_emotion,
-      label: "Que ressentiriez-vous en donnant plus ?",
-      collection: User.own_emotions, as: :radio_buttons,
-      wrapper_html: { class: 'q3' } %>
-  <%= u.input :other_emotion,
-      label: "Que verriez-vous dans le regard des autres sur vous si vous donniez plus ?",
-      collection: User.other_emotions, as: :radio_buttons,
-      wrapper_html: { class: 'q4' } %>
-  <%= u.input :preferred_mean,
-      label: "Que préféreriez-vous faire pour donner plus ?",
-      collection: User.preferred_means, as: :radio_buttons,
-      wrapper_html: { class: 'q5' } %>
-  <%= u.input :money_wish,
-      label: "Si nous vous faisions économiser plusieurs centaines d'euros par an, vous en feriez quoi ?",
-      wrapper_html: { class: 'q6' } %>
-  <%= u.input :email,
-      label: "A quelle adresse mail pouvons-nous vous contacter lorsque nous serons prêts ?",
-      placeholder: "jean@orange.fr",
-      wrapper_html: { class: 'q7' } %>
-  <%= u.input :main_mobility_mode,
-      label: "Quel est votre mode de transport habituel ?",
-      collection: User.main_mobility_modes, as: :radio_buttons,
-      wrapper_html: { class: 'q8' } %>
-  <%= u.input :motor_vehicle_owner,
-      label: "Etes-vous propriétaire d'un véhicule ? (cochez si oui)",
-      wrapper_html: { class: 'q9' } %>
-  <%= u.input :age_bracket, label: "Dans quelle tranche d'âge êtes-vous ?",
-      collection: User.age_brackets, as: :radio_buttons,
-      wrapper_html: { class: 'q10' } %>
-  <%= u.input :po_code, label: "Quel est votre code postal ?",
-      placeholder: "33000",
-      wrapper_html: { class: 'q11' } %>
-  <%= u.input :mob_number, label: "Quel est votre numéro de portable ?",
-      placeholder: "06........",
-      wrapper_html: { class: 'q12' } %>
-  <%= u.input :first_name, label: "Quel est votre prénom ?",
-      wrapper_html: { class: 'q13' } %>
-  <%= u.input :last_name, label: "Quel est votre nom ?",
-      wrapper_html: { class: 'q14' } %>
-  <%= u.button :submit %>
-<% end %>
-<button class="btn btn-primary" id="next-question">Confirmer et passer à la question suivante</button>
-<button class="btn btn-success" onclick="new_user.submit()">Envoyer vos réponses</button>
-<div class="error-message"></div>
+<div class="container" >
+  <%= simple_form_for @user, remote: true do |u| %>
+    <%= u.input :amount_bracket,
+        label: "Combien avez-vous donné en 2017 à des associations ?",
+        collection: User.amount_brackets, as: :radio_buttons,
+        wrapper_html: { class: 'q1' },
+        wrapper: :vertical_radio_and_checkboxes,
+        error: "Merci de choisir un montant pour passer à la suite" %>
+    <%= u.input :cause,
+        label: "A quelle cause donneriez-vous (plus) si vous le pouviez ?",
+        collection: User.causes, as: :radio_buttons,
+        wrapper_html: { class: 'q2' } %>
+    <%= u.input :own_emotion,
+        label: "Que ressentiriez-vous en donnant plus ?",
+        collection: User.own_emotions, as: :radio_buttons,
+        wrapper_html: { class: 'q3' } %>
+    <%= u.input :other_emotion,
+        label: "Que verriez-vous dans le regard des autres sur vous si vous donniez plus ?",
+        collection: User.other_emotions, as: :radio_buttons,
+        wrapper_html: { class: 'q4' } %>
+    <%= u.input :preferred_mean,
+        label: "Que préféreriez-vous faire pour donner plus ?",
+        collection: User.preferred_means, as: :radio_buttons,
+        wrapper_html: { class: 'q5' } %>
+    <%= u.input :money_wish,
+        label: "Si nous vous faisions économiser plusieurs centaines d'euros par an, vous en feriez quoi ?",
+        wrapper_html: { class: 'q6' } %>
+    <%= u.input :email,
+        label: "A quelle adresse mail pouvons-nous vous contacter lorsque nous serons prêts ?",
+        placeholder: "jean@orange.fr",
+        wrapper_html: { class: 'q7' } %>
+    <%= u.input :main_mobility_mode,
+        label: "Quel est votre mode de transport habituel ?",
+        collection: User.main_mobility_modes, as: :radio_buttons,
+        wrapper_html: { class: 'q8' } %>
+    <%= u.input :motor_vehicle_owner,
+        label: "Etes-vous propriétaire d'un véhicule ? (cochez si oui)",
+        wrapper_html: { class: 'q9' } %>
+    <%= u.input :age_bracket, label: "Dans quelle tranche d'âge êtes-vous ?",
+        collection: User.age_brackets, as: :radio_buttons,
+        wrapper_html: { class: 'q10' } %>
+    <%= u.input :po_code, label: "Quel est votre code postal ?",
+        placeholder: "33000",
+        wrapper_html: { class: 'q11' } %>
+    <%= u.input :mob_number, label: "Quel est votre numéro de portable ?",
+        placeholder: "06........",
+        wrapper_html: { class: 'q12' } %>
+    <%= u.input :first_name, label: "Quel est votre prénom ?",
+        wrapper_html: { class: 'q13' } %>
+    <%= u.input :last_name, label: "Quel est votre nom ?",
+        wrapper_html: { class: 'q14' } %>
+    <%= u.button :submit %>
+  <% end %>
+  <button class="btn btn-primary" id="next-question">Confirmer et passer à la question suivante</button>
+  <button class="btn btn-success" onclick="new_user.submit()">Envoyer vos réponses</button>
+  <div class="error-message"></div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,9 +4,7 @@
   <button class="btn btn-primary">Démarrer le questionnaire</button>
 <% end %>
 
-<div class="container" >
-  <div id="q-form" style="display:none;"></div>
-</div>
+<div id="q-form" style="display:none;"></div>
 
 <h1 id="wf" style="opacity:0; width: 600px; margin-top:1.1em; display:none; margin-bottom:1em">Merci </h1>
 </div>


### PR DESCRIPTION
CSS amélioré.
J'ai overridé le display des radio-buttons et surtout compris comment les aligner automatiquement en justifié à gauche à peu près centré sur la largeur du conteneur.
Trick: calc(50% - 100px) rend la moitié du nombre de pixels du parent et y retire 100pixels (en l'occurrence correspond à la moitié de la longueur max de mes choix dans les étapes du formulaire).